### PR TITLE
don't escape radio input element

### DIFF
--- a/snippets/radio.sublime-snippet
+++ b/snippets/radio.sublime-snippet
@@ -2,10 +2,10 @@
     <content><![CDATA[
 <div class="checkbox">
     <label for="${1:radio_group_name}" class="checkbox">
-        {{ Form::radio('${1:radio_group_name}',${2: null},${3:  null}, array(
+        {!! Form::radio('${1:radio_group_name}',${2: null},${3:  null}, array(
             'class' => 'form-control',
             'id'    => '${4:radio_id}',
-        )) }} ${5:Checkbox label}
+        )) !!} ${5:Checkbox label}
     </label>
 </div>
 ]]></content>


### PR DESCRIPTION
thanks for the snippets. I noticed the radio input element was being escaped. Fixed it up. 
